### PR TITLE
feat: helper script to add a maintainer

### DIFF
--- a/filters/search_by_repo.jq
+++ b/filters/search_by_repo.jq
@@ -1,0 +1,8 @@
+[
+    .rulesets[]
+    | select(.repository | contains($ruleset))
+]
+| if length > 0 
+    then map(.repository)[]
+    else "ERROR: no matches for " + $ruleset | halt_error(1)
+  end

--- a/scripts/add_maintainer.sh
+++ b/scripts/add_maintainer.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Convenience script to edit the rulesets.json file
+set -o errexit -o nounset -o pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+command -v "jq" &> /dev/null || {
+    echo >&2 "ERROR: jq needs to be installed, see https://jqlang.github.io/jq/download/"
+    exit 1
+}
+
+echo "NOTE: if the ruleset comes from Bazel Central Registry, it's better to add the maintainer there!"
+echo
+read -rp "Search for a ruleset: " ruleset
+matches=$(jq --raw-output --arg ruleset "$ruleset" --from-file "$SCRIPT_DIR/../filters/search_by_repo.jq" "$SCRIPT_DIR/../rulesets.json")
+PS3="Select match: "
+select repo in $matches; do
+    break
+done
+echo "Adding a maintainer for $repo"
+read -rp "Maintainer name: " name
+read -rp "Maintainer email: " email
+read -rp "Maintainer github: " github
+
+edited=$(mktemp)
+jq "{name: \"$name\", email: \"$email\", github: \"$github\"} as \$new | .rulesets |= map( if (.repository == \"$repo\") then (.maintainers += [\$new]) else . end)" "$SCRIPT_DIR/../rulesets.json" > "$edited"
+
+if [[ -n "${DRY_RUN:-}" ]]; then
+  echo "Result in $edited"
+else
+  cp "$edited" "${SCRIPT_DIR}"/../rulesets.json
+  echo "Wrote result to rulesets.json."
+fi


### PR DESCRIPTION
Demo:

```
alexeagle@13-Aspect-MBP bazel-catalog % ./scripts/add_maintainer.sh 
NOTE: if the ruleset comes from Bazel Central Registry, it's better to add the maintainer there!

Search for a ruleset: nano
1) github:wjakob/nanobind
Select match: 1
Adding a maintainer for github:wjakob/nanobind
Maintainer name: Alex Eagle
Maintainer email: alex@aspect.dev
Maintainer github: alexeagle
Wrote result to rulesets.json.
alexeagle@13-Aspect-MBP bazel-catalog % git diff
diff --git a/rulesets.json b/rulesets.json
index 4767cb1..e92e2af 100644
--- a/rulesets.json
+++ b/rulesets.json
@@ -925,7 +925,13 @@
     },
     {
       "repository": "github:wjakob/nanobind",
-      "maintainers": []
+      "maintainers": [
+        {
+          "name": "Alex Eagle",
+          "email": "alex@aspect.dev",
+          "github": "alexeagle"
+        }
+      ]
     }
   ]
 }
```